### PR TITLE
Fix bugs

### DIFF
--- a/wallet/src/de/schildbach/wallet/exchangerate/CoinGecko.java
+++ b/wallet/src/de/schildbach/wallet/exchangerate/CoinGecko.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -39,7 +40,7 @@ import java.util.Map;
  */
 public final class CoinGecko {
     private static final HttpUrl URL = HttpUrl.parse("https://api.coingecko.com/api/v3/exchange_rates");
-    private static final MediaType MEDIA_TYPE = MediaType.get("application/json");
+    private static final MediaType MEDIA_TYPE = MediaType.parse("application/json");
     private static final String SOURCE = "CoinGecko.com";
 
     private static final Logger log = LoggerFactory.getLogger(CoinGecko.class);
@@ -67,7 +68,8 @@ public final class CoinGecko {
             final ExchangeRateJson exchangeRate = entry.getValue();
             if (exchangeRate.type == Type.FIAT) {
                 try {
-                    final Fiat rate = Fiat.parseFiatInexact(symbol, exchangeRate.value);
+                    final String valueAsPlainString = BigDecimal.valueOf(exchangeRate.value).toPlainString();
+                    final Fiat rate = Fiat.parseFiatInexact(symbol, valueAsPlainString);
                     if (rate.signum() > 0)
                         result.add(new ExchangeRateEntry(SOURCE, new ExchangeRate(rate)));
                 } catch (final ArithmeticException x) {
@@ -94,7 +96,7 @@ public final class CoinGecko {
     private static class ExchangeRateJson {
         public String name;
         public String unit;
-        public String value;
+        public double value;
         public Type type;
     }
 }

--- a/wallet/src/de/schildbach/wallet/util/WalletUtils.java
+++ b/wallet/src/de/schildbach/wallet/util/WalletUtils.java
@@ -69,9 +69,15 @@ public class WalletUtils {
     public static long longHash(final Sha256Hash hash) {
         final byte[] bytes = hash.getBytes();
 
-        return (bytes[31] & 0xFFl) | ((bytes[30] & 0xFFl) << 8) | ((bytes[29] & 0xFFl) << 16)
-                | ((bytes[28] & 0xFFl) << 24) | ((bytes[27] & 0xFFl) << 32) | ((bytes[26] & 0xFFl) << 40)
-                | ((bytes[25] & 0xFFl) << 48) | ((bytes[23] & 0xFFl) << 56);
+        // Compose a little-endian 64-bit value from the last 8 bytes
+        return (bytes[31] & 0xFFL)
+                | ((bytes[30] & 0xFFL) << 8)
+                | ((bytes[29] & 0xFFL) << 16)
+                | ((bytes[28] & 0xFFL) << 24)
+                | ((bytes[27] & 0xFFL) << 32)
+                | ((bytes[26] & 0xFFL) << 40)
+                | ((bytes[25] & 0xFFL) << 48)
+                | ((bytes[24] & 0xFFL) << 56);
     }
 
     private static class MonospaceSpan extends TypefaceSpan {

--- a/wallet/test/de/schildbach/wallet/util/WalletUtilsLongHashTest.java
+++ b/wallet/test/de/schildbach/wallet/util/WalletUtilsLongHashTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.util;
+
+import org.bitcoinj.core.Sha256Hash;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression tests for {@link WalletUtils#longHash(Sha256Hash)}.
+ */
+public class WalletUtilsLongHashTest {
+    @Test
+    public void longHash_bytesSequence() {
+        final byte[] bytes = new byte[32];
+        for (int i = 0; i < 32; i++) {
+            bytes[i] = (byte) i;
+        }
+        final Sha256Hash hash = Sha256Hash.wrap(bytes);
+        final long value = WalletUtils.longHash(hash);
+        assertEquals(0x18191A1B1C1D1E1FL, value);
+    }
+}


### PR DESCRIPTION
Fix CoinGecko fiat rate parsing, correct a `WalletUtils.longHash` byte-indexing bug, and add a regression test.

---
<a href="https://cursor.com/background-agent?bcId=bc-63d47247-7be7-4b2a-ad99-970465dd2ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63d47247-7be7-4b2a-ad99-970465dd2ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More precise fiat exchange rate parsing to improve display accuracy and stability.
- Bug Fixes
  - Corrected 64-bit hash calculation to ensure consistent results across features that rely on hash-derived values.
  - Improved compatibility of exchange-rate requests for greater reliability.
- Tests
  - Added a regression test to verify the corrected hash calculation and prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->